### PR TITLE
add tud_change_titlesize option to control title styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ Unless specified otherwise, see [Usage](#usage), this extension also automatical
 - a Delft University of Technology favicon;
 - the Delft University of Technology preferred fonts;
 - rendering text inside MathJax as the surrounding text;
-- an always visible logo (i.e. a sticky logo).
+- an always visible logo (i.e. a sticky logo);
+- a bigger title.
 
 You can see how the TU Delft theme looks like applied in this [example book](http://teachbooks.io/TU-Delft-Theme-Example/).
 
@@ -52,7 +53,7 @@ sphinx-tudelft-theme
 **Step 3: Enable in `_config.yml`**
 
 In your `_config.yml` file, add the extension to the list of Sphinx extra extensions (**important**: underscore, not dash this time):
-```
+```yaml
 sphinx: 
     extra_extensions:
         .
@@ -98,7 +99,7 @@ where `<color>` is one of the following colors:
 and `<math>` is the $\LaTeX$ that should be rendered in the color `<color>`.
 
 If a Delft University of Technology logo should not be set (i.e. use logos defined by the user), include the following in your `_config.yml` file:
-```
+```yaml
 sphinx:
   config:
     ...
@@ -106,7 +107,7 @@ sphinx:
 ```
 
 If a Delft University of Technology favicon should not be set (i.e. use a favicon defined by the user), include the following in your `_config.yml` file:
-```
+```yaml
 sphinx:
   config:
     ...
@@ -114,7 +115,7 @@ sphinx:
 ```
 
 If the Delft University of Technology fonts should not be set (i.e. use fonts defined by the user), include the following in your `_config.yml` file:
-```
+```yaml
 sphinx:
   config:
     ...
@@ -122,7 +123,7 @@ sphinx:
 ```
 
 If rendering text inside MathJax should not be the same as the surrounding html, include the following in your `_config.yml` file:
-```
+```yaml
 sphinx:
   config:
     ...
@@ -130,13 +131,21 @@ sphinx:
 ```
 
 If a sticky logo is not preferred, include the following in your `_config.yml` file:
-```
+```yaml
 sphinx:
   config:
     ...
     tud_sticky_logo: false
 ```
 
+If the title styling should not be altered (i.e. use title styling defined by the user), include the following in your `_config.yml` file:
+
+```yaml
+sphinx:
+  config:
+    ...
+    tud_change_titlesize: false
+```
 
 ## Contribute
 This tool's repository is stored on [GitHub](https://github.com/TeachBooks/Sphinx-TUDelft-theme). The `README.md` of the branch `Manual` is also part of the [TeachBooks manual](https://teachbooks.io/manual/intro.html) as a submodule. If you'd like to contribute, you can create a fork and open a pull request on the [GitHub repository](https://github.com/TeachBooks/Sphinx-TUDelft-theme). To update the `README.md` shown in the TeachBooks manual, create a fork and open a merge request for the [GitHub repository of the manual](https://github.com/TeachBooks/manual). If you intent to clone the manual including its submodules, clone using: `git clone --recurse-submodulesgit@github.com:TeachBooks/manual.git`.

--- a/src/sphinx_tudelft_theme/__init__.py
+++ b/src/sphinx_tudelft_theme/__init__.py
@@ -17,18 +17,24 @@ def copy_stylesheet(app: Sphinx, exc: None) -> None:
         fonts_src_dir = os.path.join(base_dir, 'static', 'RobotoSlab-Regular.woff')
     if app.config.tud_sticky_logo:
         sticky = os.path.join(base_dir, 'static', 'sticky-logo.css')
+    if app.config.tud_change_titlesize:
+        title = os.path.join(base_dir, 'static', 'tudelft_title.css')
     
     if app.builder.format == 'html' and not exc:
         static_dir = os.path.join(app.builder.outdir, '_static')
 
         copy_asset_file(style, static_dir)
         if app.config.tud_change_fonts:
-            
+            print('Copying TU Delft fonts')
             copy_asset_file(fonts, static_dir)
             copy_asset_file(fonts_src_dir2, static_dir)
             copy_asset_file(fonts_src_dir, static_dir)
         if app.config.tud_sticky_logo:
-            copy_asset_file(sticky, static_dir)            
+            print('Copying sticky logo CSS')
+            copy_asset_file(sticky, static_dir)
+        if app.config.tud_change_titlesize:
+            print('Copying TU Delft title styling')
+            copy_asset_file(title, static_dir)            
 
 def copy_logos(app: Sphinx, exc: None) -> None:
     if app.config.tud_change_logo:
@@ -99,9 +105,11 @@ def setup(app: Sphinx):
     app.add_config_value('tud_change_fonts', True, 'env')
     app.add_config_value('tud_change_mtext', True, 'env')
     app.add_config_value('tud_sticky_logo', True, 'env')
+    app.add_config_value('tud_change_titlesize', True, 'env')
     app.add_css_file('tudelft_style.css')
     app.add_css_file('tudelft_fonts.css')
     app.add_css_file('sticky-logo.css')
+    app.add_css_file('tudelft_title.css')
     app.connect('build-finished', copy_stylesheet)
     app.connect('build-finished', copy_logos)
     app.connect('build-finished', copy_favicon)

--- a/src/sphinx_tudelft_theme/static/tudelft_style.css
+++ b/src/sphinx_tudelft_theme/static/tudelft_style.css
@@ -97,15 +97,6 @@
     background-color: var(--pst-color-primary) !important;
 }
 
-
-/* Set title to scale to max width of 100% */
-.title.logo__title {
-      width: 100%;
-      font-size: clamp(1rem, 4vw, 2rem);
-      text-align: center;
-      margin: 0;
-      padding: 0.5rem 0;
-    }
   
   /* BLOCK COMPONENTS (admonitions, proofs, exercises) */
 

--- a/src/sphinx_tudelft_theme/static/tudelft_title.css
+++ b/src/sphinx_tudelft_theme/static/tudelft_title.css
@@ -1,0 +1,8 @@
+/* Set title to scale to max width of 100% */
+.title.logo__title {
+      width: 100%;
+      font-size: clamp(1rem, 4vw, 2rem);
+      text-align: center;
+      margin: 0;
+      padding: 0.5rem 0;
+    }


### PR DESCRIPTION
## Changes
- Created separate `tudelft_title.css` file for title styling
- Added `tud_change_titlesize` config option (defaults to `true`)
- Updated documentation and feature list
- Follows existing pattern for conditional CSS features

## Usage
```yaml
sphinx:
  config:
    tud_change_titlesize: false
```